### PR TITLE
Use absolute path for binary, put component in config for different component

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -2,6 +2,7 @@
     "token": "https://confluence.atlassian.com/cloud/api-tokens-938839638.html",
     "email": "email that bind to your JIRA account",
     "user_id": "user id in that jira account",
-    "test": false, 
-    "project":"JIRA Project code, e.g. STL, BUS, fill with your project domain"
+    "test": false,
+    "project": "JIRA Project code, e.g. STL, BUS, fill with your project domain",
+    "component": "Fill with your project component, you can get it here https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-createmeta-get"
 }

--- a/config.go
+++ b/config.go
@@ -2,17 +2,20 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 )
 
 // JiraConfig is a config to communicate with JIRA account.
 type JiraConfig struct {
-	Token   string `json:"token,omitempty"`
-	Email   string `json:"email,omitempty"`
-	UserID  string `json:"user_id,omitempty"`
-	Test    bool   `json:"test,omitempty"`
-	Project string `json:"project"`
+	Token     string `json:"token,omitempty"`
+	Email     string `json:"email,omitempty"`
+	UserID    string `json:"user_id,omitempty"`
+	Test      bool   `json:"test,omitempty"`
+	Project   string `json:"project"`
+	Component string `json:"component"`
 }
 
 var defaultConfig *JiraConfig
@@ -23,7 +26,12 @@ func getJiraConfig() *JiraConfig {
 		return defaultConfig
 	}
 
-	file, err := os.Open("config.json")
+	// To get the path if user store the binary in $PATH
+	file, err := os.Open(getBinaryPath() + "/config.json")
+	if err != nil {
+		file, err = os.Open("config.json")
+	}
+
 	defer file.Close()
 
 	if err == nil {
@@ -36,4 +44,12 @@ func getJiraConfig() *JiraConfig {
 	}
 
 	return nil
+}
+
+func getBinaryPath() string {
+	e, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprint(path.Dir(e))
 }

--- a/template.go
+++ b/template.go
@@ -16,7 +16,7 @@ func getTemplate(jiraConfig *JiraConfig, releaseDate string, service string) str
 			},
 			"components": [
 				{
-				"name": "BACKEND"
+				"name": "%s"
 				}
 			],
 			"assignee": {
@@ -25,5 +25,5 @@ func getTemplate(jiraConfig *JiraConfig, releaseDate string, service string) str
 		}
 	}`
 
-	return fmt.Sprintf(template, jiraConfig.Project, releaseDate, service, jiraConfig.UserID)
+	return fmt.Sprintf(template, jiraConfig.Project, releaseDate, service, jiraConfig.Component, jiraConfig.UserID)
 }


### PR DESCRIPTION
- Create absolute path for the config. Use case, if user put the binary in a folder that has been registered to `$PATH`, they can't run it from every where as CLI
- Set `component` name as config, for example flight pricing team use different component, so it will return error every time user create a task that doesn't use `BACKEND` as it's component name

Created task:
<redacted>